### PR TITLE
Expose init to ObjC

### DIFF
--- a/Source/UsercentricsAdapter.swift
+++ b/Source/UsercentricsAdapter.swift
@@ -61,8 +61,15 @@ public final class UsercentricsAdapter: NSObject, ConsentAdapter {
     /// Instantiates a UsercentricsAdapter module which can be passed on a call to ``ChartboostCore.initializeSDK()`
     /// - parameter options: The options to initialize Usercentrics with. Refer to the Usercentrics documentation:
     /// https://docs.usercentrics.com/cmp_in_app_sdk/latest/getting_started/configure/
+    @objc public convenience init(options: UsercentricsOptions) {
+        self.init(options: options, chartboostCoreDPSName: UsercentricsAdapter.defaultChartboostCoreDPSName)
+    }
+
+    /// Instantiates a UsercentricsAdapter module which can be passed on a call to ``ChartboostCore.initializeSDK()`
+    /// - parameter options: The options to initialize Usercentrics with. Refer to the Usercentrics documentation:
+    /// https://docs.usercentrics.com/cmp_in_app_sdk/latest/getting_started/configure/
     /// - parameter chartboostCoreDPSName: The name for the Chartboost Core DPS that matches the one set on the Usercentrics dashboard.
-    public init(options: UsercentricsOptions, chartboostCoreDPSName: String = UsercentricsAdapter.defaultChartboostCoreDPSName) {
+    @objc public init(options: UsercentricsOptions, chartboostCoreDPSName: String = UsercentricsAdapter.defaultChartboostCoreDPSName) {
         self.options = options
         self.chartboostCoreDPSName = chartboostCoreDPSName
     }


### PR DESCRIPTION
Parameters with default values are not exposed to Obj-C, so we need to duplicate the init definition