### PR TITLE
Update for new APIs and expected behaviors

### DIFF
--- a/Source/UsercentricsAdapter.swift
+++ b/Source/UsercentricsAdapter.swift
@@ -146,7 +146,7 @@ public final class UsercentricsAdapter: NSObject, ConsentAdapter {
 
     /// Informs the CMP that the user has granted consent.
     /// This method should be used only when a custom consent dialog is presented to the user, thereby making the publisher
-    /// responsible for the UI-side of collecting consent. In most cases ``showConsentDialog(_:from:completion:)``should
+    /// responsible for the UI-side of collecting consent. In most cases ``showConsentDialog(_:from:completion:)`` should
     /// be used instead.
     /// If the CMP does not support custom consent dialogs or the operation fails for any other reason, the completion
     /// handler is executed with a `false` parameter.


### PR DESCRIPTION
Split setConsentStatus() method into 3.
Block initialization until consent info is fetched, fail if it can't be.
Properly retry initialization if needed whenever any action is performed after a call to reset().
Trigger delegate updates only with the final consent info on reset() (instead of calling first with unknown, then with whatever usercentrics ends up with).