### PR TITLE
HB-6315: Remove 2022 from copyright header

### DIFF
--- a/Source/UsercentricsAdapter.swift
+++ b/Source/UsercentricsAdapter.swift
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Chartboost, Inc.
+// Copyright 2023 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.


### PR DESCRIPTION
The Core SDK started in 2023, not 2022. Will need to added "2023-" to the header at the end of this year.