### PR TITLE
HB-6343: pass `chartboostApplicationIdentifier` from SDK to modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,5 +3,9 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Core SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Core SDK version within that major version.
 
+### 0.2.8.0.1
+- Adopt `ConsentAdapter` API updates in the ChartboostCore SDK 0.3.0.
+- This version of the adapters has been certified with UsercentricsUI 2.8.0.
+
 ### 0.2.8.0.0
 - This version of the adapters has been certified with UsercentricsUI 2.8.0.

--- a/ChartboostCoreConsentAdapterUsercentrics.podspec
+++ b/ChartboostCoreConsentAdapterUsercentrics.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name        = 'ChartboostCoreConsentAdapterUsercentrics'
-  spec.version     = '0.2.8.0.0'
+  spec.version     = '0.2.8.0.1'
   spec.license     = { :type => 'MIT', :file => 'LICENSE.md' }
   spec.homepage    = 'https://github.com/ChartBoost/chartboost-core-ios-consent-adapter-usercentrics'
   spec.authors     = { 'Chartboost' => 'https://www.chartboost.com/' }
@@ -19,8 +19,8 @@ Pod::Spec.new do |spec|
   # System frameworks used
   spec.ios.frameworks = ['Foundation', 'UIKit']
   
-  # This adapter is compatible with all Chartboost Core 0.X versions of the SDK.
-  spec.dependency 'ChartboostCoreSDK', '~> 0.0'
+  # This adapter is compatible with Chartboost Core 0.3+ versions of the SDK.
+  spec.dependency 'ChartboostCoreSDK', '~> 0.3'
 
   # CMP SDK and version that this adapter is certified to work with.
   spec.dependency 'UsercentricsUI', '~> 2.8.0'

--- a/Source/UsercentricsAdapter.swift
+++ b/Source/UsercentricsAdapter.swift
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Chartboost, Inc.
+// Copyright 2023-2023 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/Source/UsercentricsAdapter.swift
+++ b/Source/UsercentricsAdapter.swift
@@ -46,7 +46,7 @@ public final class UsercentricsAdapter: NSObject, ConsentAdapter {
     public let moduleID = "usercentrics"
 
     /// The version of the module.
-    public let moduleVersion = "0.2.8.0.0"
+    public let moduleVersion = "0.2.8.0.1"
 
     /// The delegate to be notified whenever any change happens in the CMP consent status.
     /// This delegate is set by Core SDK and is an essential communication channel between Core and the CMP.
@@ -134,9 +134,10 @@ public final class UsercentricsAdapter: NSObject, ConsentAdapter {
     }
 
     /// Sets up the module to make it ready to be used.
-    /// - completion: A completion handler to be executed when the module is done initializing.
+    /// - parameter configuration: A ``ModuleInitializationConfiguration`` for configuring the module.
+    /// - parameter completion: A completion handler to be executed when the module is done initializing.
     /// An error should be passed if the initialization failed, whereas `nil` should be passed if it succeeded.
-    public func initialize(completion: @escaping (Error?) -> Void) {
+    public func initialize(configuration: ModuleInitializationConfiguration, completion: @escaping (Error?) -> Void) {
         // Configure the SDK and fetch initial consent status.
         // We don't report consent changes to the delegate here since we are restoring the info from whatever the SDK has saved.
         initializeAndUpdateConsentInfo(reportingChanges: false, isFirstInitialization: true, completion: completion)


### PR DESCRIPTION
The module protocol is updated in https://github.com/ChartBoost/chartboost-core-ios-sdk-private/pull/132